### PR TITLE
Fix nix build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,11 +6,14 @@ in
     version = manifest.version;
     cargoLock.lockFile = ./Cargo.lock;
     src = pkgs.lib.cleanSource ./.;
+    nativeBuildInputs = with pkgs; [
+      pkg-config
+      writableTmpDirAsHomeHook
+    ];
     buildInputs = with pkgs; [
       fontconfig
       alsa-lib
       libx11
       libxkbcommon
     ];
-    nativeBuildInputs = with pkgs; [pkg-config];
   }


### PR DESCRIPTION
The following tests cause the nix build to fail currently:

- `leaderboard::tests::test_get_config_dir`
- `leaderboard::tests::test_load_entries_empty_file`
- `leaderboard::tests::test_save_and_load_entries`

The reason is that, by default, `$HOME` isn't a writable directory during a nix build. Adding `writableTmpDirAsHomeHook` fixes this by creating a temporary writable directory and setting `$HOME` to it